### PR TITLE
⚡️ Switch from `serde` to `serde_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "heapless",
  "paste",
  "portable-atomic",
- "serde",
+ "serde_core",
  "serde_json",
 ]
 
@@ -95,7 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,14 @@ license = "MIT"
 
 [features]
 default = ["alloc"]
-alloc = ["serde?/alloc"]
+alloc = ["serde_core?/alloc"]
 heapless = ["dep:heapless"]
-serde = ["dep:serde", "heapless?/serde"]
+serde = ["dep:serde_core", "heapless?/serde"]
 portable-atomic = ["dep:portable-atomic", "heapless?/portable-atomic"]
 
 [dependencies]
 heapless = { version = "0.9", optional = true }
-serde = { version = "1", default-features = false, features = [
-    "derive",
-], optional = true }
+serde_core = { version = "1", default-features = false, optional = true }
 portable-atomic = { version = "1", optional = true }
 paste = "1.0"
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -17,7 +17,6 @@ type Inner<const N: usize> = heapless::String<N>;
 /// is a wrapper around `alloc::string::String`, setting the initial capacity to `N`. All fallible
 /// operations are in reality infallible and all unsafe methods are safe in the latter case.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct String<const N: usize>(Inner<N>);
 
 impl<const N: usize> String<N> {
@@ -381,3 +380,23 @@ impl_try_from_num!(u8, 3);
 impl_try_from_num!(u16, 5);
 impl_try_from_num!(u32, 10);
 impl_try_from_num!(u64, 20);
+
+#[cfg(feature = "serde")]
+impl<'de, const N: usize> serde_core::Deserialize<'de> for String<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        Inner::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const N: usize> serde_core::Serialize for String<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde_core::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -17,7 +17,6 @@ pub(crate) type Inner<T, const N: usize> = heapless::Vec<T, N>;
 /// a wrapper around `alloc::vec::Vec`, setting the initial capacity to `N`. All fallible
 /// operations are in reality infallible and all unsafe methods are safe in the latter case.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vec<T, const N: usize>(Inner<T, N>);
 
 impl<T, const N: usize> Vec<T, N> {
@@ -645,5 +644,31 @@ impl<T, const N: usize> AsMut<[T]> for Vec<T, N> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, const N: usize> serde_core::Serialize for Vec<T, N>
+where
+    T: serde_core::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde_core::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, const N: usize> serde_core::Deserialize<'de> for Vec<T, N>
+where
+    T: serde_core::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        Inner::deserialize(deserializer).map(Self)
     }
 }


### PR DESCRIPTION
This new split of `serde` crate, enables faster compilation by allowing
non-derive needing parts (such as this library) to be compiled in
parallel to `serde_derive` crate.

This also implies removal of `serde_derive` as an indirect dependency of
this crate.

A run of `cargo build --features serde` in this repo itself goes from 5s
to 1s (on my machine), which is a pretty big improvement.
